### PR TITLE
Switch Value and subtypes to protocol + structs

### DIFF
--- a/LLVM/BasicBlock.swift
+++ b/LLVM/BasicBlock.swift
@@ -14,8 +14,8 @@ public class BasicBlock {
         return Function(maybeRef: LLVMGetBasicBlockParent(ref))
     }
     
-    public var terminator: TerminatorInstruction? {
-        return TerminatorInstruction(maybeRef: LLVMGetBasicBlockTerminator(ref))
+    public var terminator: TerminatorInstructionType? {
+        return AnyTerminatorInstruction(maybeRef: LLVMGetBasicBlockTerminator(ref))
     }
     
     public func insertInContext(context: Context, name: String) -> BasicBlock {
@@ -39,11 +39,11 @@ public class BasicBlock {
         LLVMMoveBasicBlockAfter(ref, block.ref)
     }
     
-    public var firstInstruction: Instruction? {
-        return Instruction(maybeRef: LLVMGetFirstInstruction(ref))
+    public var firstInstruction: InstructionType? {
+        return AnyInstruction(maybeRef: LLVMGetFirstInstruction(ref))
     }
     
-    public var lastInstruction: Instruction? {
-        return Instruction(maybeRef: LLVMGetLastInstruction(ref))
+    public var lastInstruction: InstructionType? {
+        return AnyInstruction(maybeRef: LLVMGetLastInstruction(ref))
     }
 }

--- a/LLVM/Builder.swift
+++ b/LLVM/Builder.swift
@@ -14,11 +14,11 @@ public class Builder {
         LLVMDisposeBuilder(ref)
     }
     
-    public func position(block block: BasicBlock, instruction: Instruction) {
+    public func position(block block: BasicBlock, instruction: InstructionType) {
         LLVMPositionBuilder(ref, block.ref, instruction.ref)
     }
     
-    public func positionBefore(instruction instruction: Instruction) {
+    public func positionBefore(instruction instruction: InstructionType) {
         LLVMPositionBuilderBefore(ref, instruction.ref)
     }
     
@@ -34,7 +34,7 @@ public class Builder {
         LLVMClearInsertionPosition(ref)
     }
     
-    public func insert(instruction instruction: Instruction, name: String? = nil) {
+    public func insert(instruction instruction: InstructionType, name: String? = nil) {
         if let name = name {
             LLVMInsertIntoBuilderWithName(ref, instruction.ref, name)
         } else {
@@ -46,7 +46,7 @@ public class Builder {
         return ReturnInstruction(ref: LLVMBuildRetVoid(ref))
     }
     
-    public func buildReturn(value value: Value) -> ReturnInstruction {
+    public func buildReturn(value value: ValueType) -> ReturnInstruction {
         return ReturnInstruction(ref: LLVMBuildRet(ref, value.ref))
     }
     
@@ -54,15 +54,15 @@ public class Builder {
         return BranchInstruction(ref: LLVMBuildBr(ref, destination.ref))
     }
     
-    public func buildConditionalBranch(condition condition: Value, thenBlock: BasicBlock, elseBlock: BasicBlock) -> BranchInstruction {
+    public func buildConditionalBranch(condition condition: ValueType, thenBlock: BasicBlock, elseBlock: BasicBlock) -> BranchInstruction {
         return BranchInstruction(ref: LLVMBuildCondBr(ref, condition.ref, thenBlock.ref, elseBlock.ref))
     }
     
-    public func buildSwitch(value value: Value, elseBlock: BasicBlock, numCases: UInt32) -> SwitchInstruction {
+    public func buildSwitch(value value: ValueType, elseBlock: BasicBlock, numCases: UInt32) -> SwitchInstruction {
         return SwitchInstruction(ref: LLVMBuildSwitch(ref, value.ref, elseBlock.ref, numCases))
     }
     
-    public func buildIndirectBranch(address address: Value, destinationHint: UInt32) -> IndirectBranchInstruction {
+    public func buildIndirectBranch(address address: ValueType, destinationHint: UInt32) -> IndirectBranchInstruction {
         return IndirectBranchInstruction(ref: LLVMBuildIndirectBr(ref, address.ref, destinationHint))
     }
     
@@ -82,290 +82,290 @@ public class Builder {
     
     // MARK: Arithmetic
     
-    public func buildAdd(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildAdd(ref, left.ref, right.ref, name))
+    public func buildAdd(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildAdd(ref, left.ref, right.ref, name))
     }
     
-    public func buildNSWAdd(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNSWAdd(ref, left.ref, right.ref, name))
+    public func buildNSWAdd(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNSWAdd(ref, left.ref, right.ref, name))
     }
     
-    public func buildNUWAdd(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNUWAdd(ref, left.ref, right.ref, name))
+    public func buildNUWAdd(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNUWAdd(ref, left.ref, right.ref, name))
     }
     
-    public func buildFAdd(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildFAdd(ref, left.ref, right.ref, name))
+    public func buildFAdd(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFAdd(ref, left.ref, right.ref, name))
     }
     
-    public func buildSub(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildSub(ref, left.ref, right.ref, name))
+    public func buildSub(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildSub(ref, left.ref, right.ref, name))
     }
     
-    public func buildNSWSub(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNSWSub(ref, left.ref, right.ref, name))
+    public func buildNSWSub(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNSWSub(ref, left.ref, right.ref, name))
     }
     
-    public func buildNUWSub(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNUWSub(ref, left.ref, right.ref, name))
+    public func buildNUWSub(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNUWSub(ref, left.ref, right.ref, name))
     }
     
-    public func buildFSub(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildFSub(ref, left.ref, right.ref, name))
+    public func buildFSub(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFSub(ref, left.ref, right.ref, name))
     }
     
-    public func buildMul(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildMul(ref, left.ref, right.ref, name))
+    public func buildMul(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildMul(ref, left.ref, right.ref, name))
     }
     
-    public func buildNSWMul(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNSWMul(ref, left.ref, right.ref, name))
+    public func buildNSWMul(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNSWMul(ref, left.ref, right.ref, name))
     }
     
-    public func buildNUWMul(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNUWMul(ref, left.ref, right.ref, name))
+    public func buildNUWMul(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNUWMul(ref, left.ref, right.ref, name))
     }
     
-    public func buildFMul(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildFMul(ref, left.ref, right.ref, name))
+    public func buildFMul(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFMul(ref, left.ref, right.ref, name))
     }
     
-    public func buildUDiv(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildUDiv(ref, left.ref, right.ref, name))
+    public func buildUDiv(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildUDiv(ref, left.ref, right.ref, name))
     }
     
-    public func buildSDiv(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildSDiv(ref, left.ref, right.ref, name))
+    public func buildSDiv(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildSDiv(ref, left.ref, right.ref, name))
     }
     
-    public func buildExactSDiv(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildExactSDiv(ref, left.ref, right.ref, name))
+    public func buildExactSDiv(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildExactSDiv(ref, left.ref, right.ref, name))
     }
     
-    public func buildFDiv(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildFDiv(ref, left.ref, right.ref, name))
+    public func buildFDiv(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFDiv(ref, left.ref, right.ref, name))
     }
     
-    public func buildURem(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildURem(ref, left.ref, right.ref, name))
+    public func buildURem(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildURem(ref, left.ref, right.ref, name))
     }
     
-    public func buildSRem(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildSRem(ref, left.ref, right.ref, name))
+    public func buildSRem(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildSRem(ref, left.ref, right.ref, name))
     }
     
-    public func buildFRem(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildFRem(ref, left.ref, right.ref, name))
+    public func buildFRem(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFRem(ref, left.ref, right.ref, name))
     }
     
-    public func buildShl(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildShl(ref, left.ref, right.ref, name))
+    public func buildShl(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildShl(ref, left.ref, right.ref, name))
     }
     
-    public func buildLShr(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildLShr(ref, left.ref, right.ref, name))
+    public func buildLShr(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildLShr(ref, left.ref, right.ref, name))
     }
     
-    public func buildAShr(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildAShr(ref, left.ref, right.ref, name))
+    public func buildAShr(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildAShr(ref, left.ref, right.ref, name))
     }
     
-    public func buildAnd(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildAnd(ref, left.ref, right.ref, name))
+    public func buildAnd(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildAnd(ref, left.ref, right.ref, name))
     }
     
-    public func buildOr(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildOr(ref, left.ref, right.ref, name))
+    public func buildOr(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildOr(ref, left.ref, right.ref, name))
     }
     
-    public func buildXor(left left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildXor(ref, left.ref, right.ref, name))
+    public func buildXor(left left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildXor(ref, left.ref, right.ref, name))
     }
     
-    public func buildBinOp(op: LLVMOpcode, left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildBinOp(ref, op, left.ref, right.ref, name))
+    public func buildBinOp(op: LLVMOpcode, left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildBinOp(ref, op, left.ref, right.ref, name))
     }
     
-    public func buildNeg(value: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNeg(ref, value.ref, name))
+    public func buildNeg(value: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNeg(ref, value.ref, name))
     }
     
-    public func buildNSWNeg(value: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNSWNeg(ref, value.ref, name))
+    public func buildNSWNeg(value: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNSWNeg(ref, value.ref, name))
     }
     
-    public func buildNUWNeg(value: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNUWNeg(ref, value.ref, name))
+    public func buildNUWNeg(value: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNUWNeg(ref, value.ref, name))
     }
     
-    public func buildFNeg(value: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildFNeg(ref, value.ref, name))
+    public func buildFNeg(value: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFNeg(ref, value.ref, name))
     }
     
-    public func buildNot(value: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildNot(ref, value.ref, name))
+    public func buildNot(value: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildNot(ref, value.ref, name))
     }
 
     // MARK: Memory
     
-    public func buildMalloc(type type: Type, name: String) -> Instruction {
-        return Instruction(ref: LLVMBuildMalloc(ref, type.ref, name))
+    public func buildMalloc(type type: TypeType, name: String) -> InstructionType {
+        return AnyInstruction(ref: LLVMBuildMalloc(ref, type.ref, name))
     }
     
-    public func buildArrayMalloc(type type: Type, value: Value, name: String) -> Instruction {
-        return Instruction(ref: LLVMBuildArrayMalloc(ref, type.ref, value.ref, name))
+    public func buildArrayMalloc(type type: TypeType, value: ValueType, name: String) -> InstructionType {
+        return AnyInstruction(ref: LLVMBuildArrayMalloc(ref, type.ref, value.ref, name))
     }
     
-    public func buildAlloca(type type: Type, name: String) -> AllocaInstruction {
+    public func buildAlloca(type type: TypeType, name: String) -> AllocaInstruction {
         return AllocaInstruction(ref: LLVMBuildAlloca(ref, type.ref, name))
     }
     
-    public func buildArrayAlloca(type type: Type, value: Value, name: String) -> AllocaInstruction {
+    public func buildArrayAlloca(type type: TypeType, value: ValueType, name: String) -> AllocaInstruction {
         return AllocaInstruction(ref: LLVMBuildArrayAlloca(ref, type.ref, value.ref, name))
     }
     
-    public func buildFree(pointer: Value) -> CallInstruction {
+    public func buildFree(pointer: ValueType) -> CallInstruction {
         return CallInstruction(ref: LLVMBuildFree(ref, pointer.ref))
     }
     
-    public func buildLoad(pointer: Value, name: String) -> LoadInstruction {
+    public func buildLoad(pointer: ValueType, name: String) -> LoadInstruction {
         return LoadInstruction(ref: LLVMBuildLoad(ref, pointer.ref, name))
     }
     
-    public func buildGEP(pointer: Value, indices: [Value], name: String) -> Value {
+    public func buildGEP(pointer: ValueType, indices: [ValueType], name: String) -> ValueType {
         var indexRefs = indices.map { $0.ref }
-        return Value(ref: LLVMBuildGEP(ref, pointer.ref, &indexRefs, UInt32(indexRefs.count), name))
+        return AnyValue(ref: LLVMBuildGEP(ref, pointer.ref, &indexRefs, UInt32(indexRefs.count), name))
     }
     
-    public func buildInBoundsGEP(pointer: Value, indices: [Value], name: String) -> Value {
+    public func buildInBoundsGEP(pointer: ValueType, indices: [ValueType], name: String) -> ValueType {
         var indexRefs = indices.map { $0.ref }
-        return Value(ref: LLVMBuildInBoundsGEP(ref, pointer.ref, &indexRefs, UInt32(indexRefs.count), name))
+        return AnyValue(ref: LLVMBuildInBoundsGEP(ref, pointer.ref, &indexRefs, UInt32(indexRefs.count), name))
     }
     
-    public func buildStructGEP(pointer: Value, index: UInt32, name: String) -> Value {
-        return Value(ref: LLVMBuildStructGEP(ref, pointer.ref, index, name))
+    public func buildStructGEP(pointer: ValueType, index: UInt32, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildStructGEP(ref, pointer.ref, index, name))
     }
     
-    public func buildGlobalString(string: String, name: String) -> GlobalVariable {
-        return GlobalVariable(ref: LLVMBuildGlobalString(ref, string, name))
+    public func buildGlobalString(string: String, name: String) -> GlobalVariableType {
+        return AnyGlobalVariable(ref: LLVMBuildGlobalString(ref, string, name))
     }
     
-    public func buildGlobalStringPointer(string: String, name: String) -> Value {
-        return Value(ref: LLVMBuildGlobalStringPtr(ref, string, name))
+    public func buildGlobalStringPointer(string: String, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildGlobalStringPtr(ref, string, name))
     }
     
     // TODO: volatile get/set
     
-    public func buildTrunc(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildTrunc(ref, value.ref, type.ref, name))
+    public func buildTrunc(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildTrunc(ref, value.ref, type.ref, name))
     }
     
-    public func buildZExt(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildZExt(ref, value.ref, type.ref, name))
+    public func buildZExt(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildZExt(ref, value.ref, type.ref, name))
     }
     
-    public func buildSExt(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildSExt(ref, value.ref, type.ref, name))
+    public func buildSExt(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildSExt(ref, value.ref, type.ref, name))
     }
     
-    public func buildFPToUI(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildFPToUI(ref, value.ref, type.ref, name))
+    public func buildFPToUI(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFPToUI(ref, value.ref, type.ref, name))
     }
     
-    public func buildFPToSI(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildFPToSI(ref, value.ref, type.ref, name))
+    public func buildFPToSI(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFPToSI(ref, value.ref, type.ref, name))
     }
 
-    public func buildUIToFP(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildUIToFP(ref, value.ref, type.ref, name))
+    public func buildUIToFP(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildUIToFP(ref, value.ref, type.ref, name))
     }
     
-    public func buildSIToFP(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildSIToFP(ref, value.ref, type.ref, name))
+    public func buildSIToFP(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildSIToFP(ref, value.ref, type.ref, name))
     }
     
-    public func buildFPTrunc(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildFPTrunc(ref, value.ref, type.ref, name))
+    public func buildFPTrunc(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFPTrunc(ref, value.ref, type.ref, name))
     }
     
-    public func buildFPExt(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildFPExt(ref, value.ref, type.ref, name))
+    public func buildFPExt(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFPExt(ref, value.ref, type.ref, name))
     }
     
-    public func buildIntToPointer(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildIntToPtr(ref, value.ref, type.ref, name))
+    public func buildIntToPointer(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildIntToPtr(ref, value.ref, type.ref, name))
     }
     
-    public func buildBitCast(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildBitCast(ref, value.ref, type.ref, name))
+    public func buildBitCast(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildBitCast(ref, value.ref, type.ref, name))
     }
     
-    public func buildAddressSpaceCast(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildAddrSpaceCast(ref, value.ref, type.ref, name))
+    public func buildAddressSpaceCast(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildAddrSpaceCast(ref, value.ref, type.ref, name))
     }
     
-    public func buildZExtOrBitCast(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildZExtOrBitCast(ref, value.ref, type.ref, name))
+    public func buildZExtOrBitCast(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildZExtOrBitCast(ref, value.ref, type.ref, name))
     }
     
-    public func buildSExtOrBitCast(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildSExtOrBitCast(ref, value.ref, type.ref, name))
+    public func buildSExtOrBitCast(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildSExtOrBitCast(ref, value.ref, type.ref, name))
     }
     
-    public func buildTrucOrBitCast(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildTruncOrBitCast(ref, value.ref, type.ref, name))
+    public func buildTrucOrBitCast(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildTruncOrBitCast(ref, value.ref, type.ref, name))
     }
     
-    public func buildCast(op: LLVMOpcode, value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildCast(ref, op, value.ref, type.ref, name))
+    public func buildCast(op: LLVMOpcode, value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildCast(ref, op, value.ref, type.ref, name))
     }
     
-    public func buildPointerCast(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildPointerCast(ref, value.ref, type.ref, name))
+    public func buildPointerCast(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildPointerCast(ref, value.ref, type.ref, name))
     }
     
-    public func buildIntCast(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildIntCast(ref, value.ref, type.ref, name))
+    public func buildIntCast(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildIntCast(ref, value.ref, type.ref, name))
     }
     
-    public func buildFPCast(value: Value, destinationType type: Type, name: String) -> Value {
-        return Value(ref: LLVMBuildFPCast(ref, value.ref, type.ref, name))
+    public func buildFPCast(value: ValueType, destinationType type: TypeType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFPCast(ref, value.ref, type.ref, name))
     }
     
-    public func buildICmp(op: LLVMIntPredicate, left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildICmp(ref, op, left.ref, right.ref, name))
+    public func buildICmp(op: LLVMIntPredicate, left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildICmp(ref, op, left.ref, right.ref, name))
     }
     
-    public func buildFCmp(op: LLVMRealPredicate, left: Value, right: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildFCmp(ref, op, left.ref, right.ref, name))
+    public func buildFCmp(op: LLVMRealPredicate, left: ValueType, right: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildFCmp(ref, op, left.ref, right.ref, name))
     }
     
-    public func buildPhi(type: Type, name: String) -> PHINode {
+    public func buildPhi(type: TypeType, name: String) -> PHINode {
         return PHINode(ref: LLVMBuildPhi(ref, type.ref, name))
     }
     
-    public func buildCall(function: Function, args: [Value], name: String) -> CallInstruction {
+    public func buildCall(function: Function, args: [ValueType], name: String) -> CallInstruction {
         var argRefs = args.map { $0.ref }
         return CallInstruction(ref: LLVMBuildCall(ref, function.ref, &argRefs, UInt32(argRefs.count), name))
     }
     
-    public func buildSelect(condition: Value, trueValue: Value, falseValue: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildSelect(ref, condition.ref, trueValue.ref, falseValue.ref, name))
+    public func buildSelect(condition: ValueType, trueValue: ValueType, falseValue: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildSelect(ref, condition.ref, trueValue.ref, falseValue.ref, name))
     }
     
-    public func buildVAArg(list: Value, type: Type, name: String) -> VAArgInstruction {
+    public func buildVAArg(list: ValueType, type: TypeType, name: String) -> VAArgInstruction {
         return VAArgInstruction(ref: LLVMBuildVAArg(ref, list.ref, type.ref, name))
     }
     
-    public func buildExtractElement(vec: Value, index: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildExtractElement(ref, vec.ref, index.ref, name))
+    public func buildExtractElement(vec: ValueType, index: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildExtractElement(ref, vec.ref, index.ref, name))
     }
     
-    public func buildInsertElement(vec: Value, value: Value, index: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildInsertElement(ref, value.ref, vec.ref, index.ref, name))
+    public func buildInsertElement(vec: ValueType, value: ValueType, index: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildInsertElement(ref, value.ref, vec.ref, index.ref, name))
     }
     
-    public func buildShuffleVector(vec1: Value, vec2: Value, mask: Value, name: String) -> Value {
-        return Value(ref: LLVMBuildShuffleVector(ref, vec1.ref, vec2.ref, mask.ref, name))
+    public func buildShuffleVector(vec1: ValueType, vec2: ValueType, mask: ValueType, name: String) -> ValueType {
+        return AnyValue(ref: LLVMBuildShuffleVector(ref, vec1.ref, vec2.ref, mask.ref, name))
     }
 }

--- a/LLVM/Const.swift
+++ b/LLVM/Const.swift
@@ -3,18 +3,27 @@
 //  Copyright © 2015 Ben Cochran. All rights reserved.
 //
 
-public class Constant : User {
-    public var isNull: Bool {
+public protocol ConstantType : ValueType {
+    var isNull: Bool { get }
+}
+
+public extension ConstantType {
+    var isNull: Bool {
         return LLVMIsNull(ref) != 0
     }
 }
 
-public class RealConstant : Constant {
-    public static func type(type: Type, value: Double) -> RealConstant {
+public struct RealConstant : ConstantType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
+
+    public static func type(type: TypeType, value: Double) -> RealConstant {
         return RealConstant(ref: LLVMConstReal(type.ref, value))
     }
     
-    public static func type(type: Type, value: String) -> RealConstant {
+    public static func type(type: TypeType, value: String) -> RealConstant {
         return RealConstant(ref: LLVMConstRealOfString(type.ref, value))
     }
     

--- a/LLVM/Function.swift
+++ b/LLVM/Function.swift
@@ -3,9 +3,14 @@
 //  Copyright © 2015 Ben Cochran. All rights reserved.
 //
 
-public class Function : Constant {
-    public convenience init(name: String, type: FunctionType, inModule module: Module) {
-        self.init(ref: LLVMAddFunction(module.ref, name, type.ref))
+public struct Function : ConstantType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
+
+    public init(name: String, type: FunctionType, inModule module: Module) {
+        ref = LLVMAddFunction(module.ref, name, type.ref)
     }
     
     public var intrinsicID: UInt32 {
@@ -78,7 +83,12 @@ public class Function : Constant {
     }
 }
 
-public class Argument : Value {
+public struct Argument : ValueType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
+
     public var attributes: LLVMAttribute {
         return LLVMGetFunctionAttr(ref)
     }

--- a/LLVM/GlobalVariable.swift
+++ b/LLVM/GlobalVariable.swift
@@ -3,14 +3,15 @@
 //  Copyright © 2015 Ben Cochran. All rights reserved.
 //
 
-public class GlobalValue : Constant {
+public protocol GlobalValueType : ConstantType { }
 
-}
+public protocol GlobalObjectType : GlobalValueType { }
 
-public class GlobalObject : GlobalValue {
+public protocol GlobalVariableType : GlobalObjectType { }
 
-}
-
-public class GlobalVariable : GlobalObject {
-    
+public struct AnyGlobalVariable : GlobalVariableType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
 }

--- a/LLVM/Instruction.swift
+++ b/LLVM/Instruction.swift
@@ -3,17 +3,26 @@
 //  Copyright © 2015 Ben Cochran. All rights reserved.
 //
 
-public class Instruction : User {
+public protocol InstructionType : UserType {
+    var parent: BasicBlock { get }
+    var nextInstruction: InstructionType? { get }
+    var previousInstruction: InstructionType? { get }
+    var opCode: LLVMOpcode { get }
+}
+
+
+
+public extension InstructionType {
     public var parent: BasicBlock {
         return BasicBlock(ref: LLVMGetInstructionParent(ref))
     }
     
-    public var nextInstruction: Instruction? {
-        return Instruction(maybeRef: LLVMGetNextInstruction(ref))
+    public var nextInstruction: InstructionType? {
+        return AnyInstruction(maybeRef: LLVMGetNextInstruction(ref))
     }
     
-    public var previousInstruction: Instruction? {
-        return Instruction(maybeRef: LLVMGetPreviousInstruction(ref))
+    public var previousInstruction: InstructionType? {
+        return AnyInstruction(maybeRef: LLVMGetPreviousInstruction(ref))
     }
     
     public var opCode: LLVMOpcode {
@@ -21,63 +30,119 @@ public class Instruction : User {
     }
 }
 
-public class TerminatorInstruction : Instruction {
-    
+public struct AnyInstruction : InstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
 }
 
-public class ReturnInstruction : TerminatorInstruction {
-    
+public protocol TerminatorInstructionType : InstructionType { }
+
+public struct AnyTerminatorInstruction : TerminatorInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
 }
 
-public class BranchInstruction : TerminatorInstruction {
-    
+public struct ReturnInstruction : TerminatorInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
 }
 
-public class SwitchInstruction : TerminatorInstruction {
-    func addCase(on: Constant, destination: BasicBlock) {
+public struct BranchInstruction : TerminatorInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
+}
+
+public struct SwitchInstruction : TerminatorInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
+    func addCase(on: ConstantType, destination: BasicBlock) {
         LLVMAddCase(ref, on.ref, destination.ref)
     }
 }
 
-public class IndirectBranchInstruction : TerminatorInstruction {
+public struct IndirectBranchInstruction : TerminatorInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
     public func addDestination(destination: BasicBlock) {
         LLVMAddDestination(ref, destination.ref)
     }
 }
 
-public class ResumeInstruction : TerminatorInstruction {
+public struct ResumeInstruction : TerminatorInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
     
 }
 
-public class InvokeInstruction : TerminatorInstruction {
+public struct InvokeInstruction : TerminatorInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
     
 }
 
-public class UnreachableInstruction : TerminatorInstruction {
+public struct UnreachableInstruction : TerminatorInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
     
 }
 
-public class CallInstruction : Instruction {
+public struct CallInstruction : InstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
     
 }
 
-public class UnaryInstruction : Instruction {
+public protocol UnaryInstructionType : InstructionType { }
+
+public struct AllocaInstruction : UnaryInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
     
 }
 
-public class AllocaInstruction : UnaryInstruction {
+public struct LoadInstruction : UnaryInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
     
 }
 
-public class LoadInstruction : UnaryInstruction {
+public struct VAArgInstruction : UnaryInstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
     
 }
 
-public class VAArgInstruction : UnaryInstruction {
-    
-}
-
-public class PHINode : Instruction {
+public struct PHINode : InstructionType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
+    }
     
 }
 

--- a/LLVM/Module.swift
+++ b/LLVM/Module.swift
@@ -46,10 +46,10 @@ public class Module {
         return Context(ref: LLVMGetModuleContext(ref), managed: false)
     }
     
-    public func typeByName(name: String) -> Type? {
+    public func typeByName(name: String) -> TypeType? {
         let typeRef = LLVMGetTypeByName(ref, name)
         if typeRef == nil { return .None }
-        return Type.foo(typeRef)
+        return AnyType(ref: typeRef)
     }
     
     public func functionByName(name: String) -> Function? {

--- a/LLVM/Use.swift
+++ b/LLVM/Use.swift
@@ -3,14 +3,14 @@
 //  Copyright © 2015 Ben Cochran. All rights reserved.
 //
 
-public class Use {
+public struct Use {
     internal var ref: LLVMUseRef
     internal init(ref: LLVMUseRef) {
         guard ref != nil else { fatalError("unexpected nil value") }
         self.ref = ref
     }
     
-    public var user: Value {
-        return Value(ref: LLVMGetUser(ref))
+    public var user: ValueType {
+        return AnyValue(ref: LLVMGetUser(ref))
     }
 }

--- a/LLVM/User.swift
+++ b/LLVM/User.swift
@@ -4,20 +4,35 @@
 //
 
 // TODO CollectionType this up
-public class User : Value {
-    public func operandAtIndex(index: UInt32) -> Value {
-        return Value(ref: LLVMGetOperand(ref, index))
+public protocol UserType : ValueType {
+    func operandAtIndex(index: UInt32) -> ValueType
+    func operandUseAtIndex(index: UInt32) -> Use
+    func setOperand(value: ValueType, atIndex: UInt32)
+    var operandCount: UInt32 { get }
+}
+
+public extension UserType {
+    public func operandAtIndex(index: UInt32) -> ValueType {
+        return AnyValue(ref: LLVMGetOperand(ref, index))
     }
     
     public func operandUseAtIndex(index: UInt32) -> Use {
         return Use(ref: LLVMGetOperandUse(ref, index))
     }
 
-    public func setOperand(value: Value, atIndex: UInt32) {
+    public func setOperand(value: ValueType, atIndex: UInt32) {
         LLVMSetOperand(ref, atIndex, value.ref)
     }
     
     public var operandCount: UInt32 {
         return UInt32(LLVMGetNumOperands(ref))
+    }
+}
+
+// TODO CollectionType this up
+public struct User : UserType {
+    public let ref: LLVMValueRef
+    public init(ref: LLVMValueRef) {
+        self.ref = ref
     }
 }

--- a/LLVM/Value.swift
+++ b/LLVM/Value.swift
@@ -3,17 +3,24 @@
 //  Copyright © 2015 Ben Cochran. All rights reserved.
 //
 
-public class Value {
-    internal var ref: LLVMValueRef
+public protocol ValueType {
+    var ref: LLVMValueRef { get }
+    init(ref: LLVMValueRef)
+    init?(maybeRef ref: LLVMValueRef)
     
-    internal init(ref: LLVMValueRef) {
-        guard ref != nil else { fatalError("unexpected nil value") }
-        self.ref = ref
-    }
+    var name: String? { get }
+    var string: String? { get }
+    var isConstant: Bool { get }
+    var isUndefined: Bool { get }
+    var uses: AnyGenerator<Use> { get }
     
-    internal init?(maybeRef ref: LLVMValueRef) {
-        self.ref = ref
+    func replaceAllUsesWith(value: ValueType)
+}
+
+public extension ValueType {
+    public init?(maybeRef ref: LLVMValueRef) {
         if ref == nil { return nil }
+        self.init(ref: ref)
     }
     
     public var name: String? {
@@ -36,7 +43,7 @@ public class Value {
         return .fromCString(string)
     }
     
-    public func replaceAllUsesWith(value: Value) {
+    public func replaceAllUsesWith(value: ValueType) {
         LLVMReplaceAllUsesWith(ref, value.ref)
     }
     
@@ -61,5 +68,13 @@ public class Value {
             return ref != nil ? Use(ref: ref) : nil
         }
     }
+}
+
+public struct AnyValue : ValueType {
+    public var ref: LLVMValueRef
     
+    public init(ref: LLVMValueRef) {
+        guard ref != nil else { fatalError("unexpected nil value") }
+        self.ref = ref
+    }
 }


### PR DESCRIPTION
This yields the correct type-erasure ideas via things like `AnyValue` (that is, we get some sort of value out of LLVM but can’t know its type at compile time).
